### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/io/hdus/table/table_utils.rs
+++ b/src/io/hdus/table/table_utils.rs
@@ -17,7 +17,7 @@ pub fn format_scientific<T>(num: T, max_len: usize) -> String
 where
     T: std::fmt::LowerExp + PartialEq + Into<f64>,
 {
-    let mut formatted = format!("{:.e}", num);
+    let mut formatted = format!("{:e}", num);
     
     // Replace "0e0" with "0.0" for zero representation.
     if formatted.contains("0e0") {


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.